### PR TITLE
Add exception stack trace to error page

### DIFF
--- a/src/main/java/com/example/jennifer_adapter/controller/EventController.java
+++ b/src/main/java/com/example/jennifer_adapter/controller/EventController.java
@@ -30,14 +30,14 @@ public class EventController {
             eventService.trigger(type);
             model.addAttribute("result", "예외가 발생하지 않았습니다: " + type);
         } catch (Exception e) {
-           model.addAttribute("result", "예외 발생 성공: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+            model.addAttribute("result", "예외 발생 성공: " + e.getClass().getSimpleName() + " - " + e.getMessage());
 
             List<String> traceList = Arrays.stream(e.getStackTrace())
                     .map(StackTraceElement::toString)
                     .collect(Collectors.toList());
-            System.out.println(">>> stackTraceList:");
-            System.out.println(">>> stackTraceList count: " + traceList.size()); // ✅ 반드시 추가
-            traceList.forEach(System.out::println);
+
+            model.addAttribute("exception", e);
+            model.addAttribute("stackTraceList", traceList);
         }
         return "result"; // 결과를 보여줄 페이지
     }


### PR DESCRIPTION
## Summary
- expose caught exception details from `EventController`
- show exception type, message and stacktrace in `result.html`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff931a608325ab52c2206d36a641